### PR TITLE
Remove reference to IDeliverable.Bits.RegularExpressions

### DIFF
--- a/IDeliverable.Bits.csproj
+++ b/IDeliverable.Bits.csproj
@@ -52,10 +52,6 @@
       <HintPath>..\..\..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="IDeliverable.Bits.RegularExpressions, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>Regex\IDeliverable.Bits.RegularExpressions.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>


### PR DESCRIPTION
Per #2, this reference is no longer needed.